### PR TITLE
error: better handle uncaught worker exceptions

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,5 +1,4 @@
-var domain = require('domain'),
-    cluster = require('cluster'),
+var cluster = require('cluster'),
     RPC = require('./rpc'),
     ClusterProcess = require('./cluster_process'),
     Worker;
@@ -44,29 +43,14 @@ Worker.prototype.applyForeignProperties = function(proc, props) {
 };
 
 /**
- * `Require` application main script inside domain.
+ * `Require` application main script.
  * Execution will be delayed until Worker became configured
  * (`configured` event fired).
  * @returns {Worker} self
  * @public
  */
 Worker.prototype.run = Worker.whenInitialized(function() {
-    var workerDomain = domain.create(),
-        workerPath = this.config.resolve('app');
-
-    workerDomain.on('error', function(error) {
-
-        // @todo: kaero: send notice about happened shit to master?
-        if (process.listeners('uncaughtException').length === 0) {
-            throw error;
-        }
-
-        process.emit('uncaughtException', error);
-    });
-
-    workerDomain.run(function() {
-        require(workerPath);
-    });
+    require(this.config.resolve('app'));
 
     return this;
 });


### PR DESCRIPTION
Hi! This PR about https://github.com/nodules/luster/blob/master/lib/worker.js#L57 workerDomain 'error' handler.
First, I think there are no reason to log error and then exit process with code 1. It is equal to throwing an exception.
Also there is an opinion that domain should consider special 'uncaughtException' event handler
