### PR TITLE
fix extensionsPath option

### DIFF
--- a/lib/cluster_process.js
+++ b/lib/cluster_process.js
@@ -125,8 +125,8 @@ ClusterProcess.prototype._onConfigured = function() {
 
     // try to use `extensionsPath` option to resolve extensions' modules
     // use worker file directory as fallback
-    extendResolvePath(path.dirname(
-        this.config.resolve('extensionsPath', this.config.resolve('app'))
+    extendResolvePath(path.resolve(
+        this.config.resolve('extensionsPath', path.dirname(this.config.resolve('app')))
     ));
 
     var self = this,


### PR DESCRIPTION
- The use of the method path.resolve allowed to use a relative path to extensions
-  extensionsPath option works correctly and uses exactly specified directory (instead it's parent)
