### PR TITLE
Let workers be respawned on WorkerWrapper#restart though

### DIFF
--- a/lib/worker_wrapper.js
+++ b/lib/worker_wrapper.js
@@ -430,7 +430,7 @@ WorkerWrapper.prototype._onStateStopped = function() {
 
     // start worker again if it persistent or in the restarting state
     // and isn't marked as dead
-    if ((this.options.persistent || this.restarting) && ! this.dead && ! this.stopping) {
+    if (((this.options.persistent && ! this.stopping) || this.restarting) && ! this.dead) {
         legacy.setImmediate(this.run.bind(this));
     }
 


### PR DESCRIPTION
Right now, this doesn't seem to happen due to the `#stop()` [call during restart](https://github.com/nodules/luster/blob/44095541de72b9f8638181a2c39a035465468db1/lib/worker_wrapper.js#L567), [setting](https://github.com/nodules/luster/blob/44095541de72b9f8638181a2c39a035465468db1/lib/worker_wrapper.js#L547) `this.stopping` flag and the [check](https://github.com/nodules/luster/blob/44095541de72b9f8638181a2c39a035465468db1/lib/worker_wrapper.js#L433) in `#_onStateStopped` which result is `false` even if it is a restart.