### PR TITLE
Fix error message LusterPortError: Can not unlink unix socket "undefined"

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -84,4 +84,3 @@ errors.LusterPortError = LusterError.create('LusterPortError',
     });
 
 module.exports = errors;
-

--- a/lib/port.js
+++ b/lib/port.js
@@ -91,23 +91,25 @@ Port.prototype.unlink = function(err, cb) {
     }
 
     if (err) {
-        // unknown error
-        cb(err);
+        cb(LusterPortError
+            .createError(LusterPortError.CODES.UNKNOWN_ERROR, err));
         return;
     }
+
+    var value = this.value;
 
     if (this.family !== Port.UNIX) {
         cb(LusterPortError
             .createError(LusterPortError.CODES.NOT_UNIX_SOCKET)
-            .bind({ value : this.value }));
+            .bind({ value : value }));
         return;
     }
 
-    fs.unlink(this.value, function(err) {
+    fs.unlink(value, function(err) {
         if (err && err.code !== 'ENOENT') {
             cb(LusterPortError
                 .createError(LusterPortError.CODES.CAN_NOT_UNLINK_UNIX_SOCKET, err)
-                .bind({ socketPath : this.value }));
+                .bind({ socketPath : value }));
             return;
         }
 


### PR DESCRIPTION
closes #31

Additionally: 

- add `LusterPortError.UNKNOWN_ERROR` for unspecified errors during unlink.

/cc @kaero 