### PR TITLE
Add notes to README about deprecation of `debug.port` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ module.exports = {
     debug : {
         // debug port for first worker; each following will
         // use previous worker port + 1
+        //
+        // deprecated: this option doesn't work with Node.js 0.12+
+        // and might be removed in future major versions
         port : 5010
     },
 


### PR DESCRIPTION
closes #34 

/cc @kaero 