### PR TITLE
Ignore stopped workers on soft restart

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -393,7 +393,12 @@ Master.prototype._restartWorkerFromQueue = function() {
         this.emit('restarted');
         this._isRestartQueued = false;
     } else {
-        this.restartQueue[0].restart();
+        if (this.restartQueue[0].state !== 'stopped') {
+            this.restartQueue[0].restart();
+        } else {
+            this.restartQueue.shift();
+            this._restartWorkerFromQueue();
+        }
     }
 };
 


### PR DESCRIPTION
Trying to call restart() on workers which were stopped due an error
causes en exception and stops soft restart.
Stopped workers should not start in soft restart.

cc/ @kaero 