### PR TITLE
Worker now emits 'disconnect' event from cluster.

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -46,6 +46,7 @@ Worker = ClusterProcess.create(function Worker() {
     this.on('initialized', broadcastEvent.bind(this, 'initialized'));
     this.on('loaded', broadcastEvent.bind(this, 'loaded'));
     this.on('ready', broadcastEvent.bind(this, 'ready'));
+    cluster.worker.on('disconnect', this.emit.bind(this, 'disconnect'));
 
     this._ready = false;
 


### PR DESCRIPTION
This allows to stop sending messages from worker when it has been disconnected