### PR TITLE
Ability to cleanup pools & workers

### DIFF
--- a/bin/luster.js
+++ b/bin/luster.js
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 const /** @type {ClusterProcess} */
     luster = require('../lib/luster'),
-    path = require('path'),
-    configFilePath = path.resolve(process.cwd(), process.argv[2] || 'luster.conf');
+    path = require('path');
+
+// config path is right after this script in process.argv
+const scriptArgvIndex = process.argv.findIndex(arg => arg === __filename || path.resolve(arg) === __filename);
+const configFilePath = path.resolve(process.cwd(), process.argv[scriptArgvIndex + 1] || 'luster.conf');
 
 luster.configure(require(configFilePath), true, path.dirname(configFilePath)).run();

--- a/lib/cluster_process.js
+++ b/lib/cluster_process.js
@@ -110,6 +110,15 @@ class ClusterProcess extends EventEmitterEx {
      * @public
      */
     configure(config, applyEnv, basedir) {
+        this._setConfig(config, applyEnv, basedir);
+        if (this.config) {
+            this.emit('configured');
+        }
+
+        return this;
+    }
+
+    _setConfig(config, applyEnv, basedir) {
         if (typeof applyEnv === 'undefined' || applyEnv) {
             Configuration.applyEnvironment(config);
         }
@@ -128,11 +137,7 @@ class ClusterProcess extends EventEmitterEx {
             // hack to tweak underlying EventEmitter max listeners
             // if your luster-based app extensively use luster events
             this.setMaxListeners(this.config.get('maxEventListeners', 100));
-
-            this.emit('configured');
         }
-
-        return this;
     }
 
     /**

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -105,4 +105,15 @@ errors.LusterMasterError = LusterError.create('LusterMasterError',
             'Pool key "%key%" is already taken'
     });
 
+/**
+ * @constructor
+ * @class LusterMasterError
+ * @augments LusterError
+ */
+errors.LusterMasterError = LusterError.create('LusterMasterError',
+    {
+        POOL_DOES_NOT_EXIST:
+            'Pool with key "%key%" does not exist'
+    });
+
 module.exports = errors;

--- a/lib/master.js
+++ b/lib/master.js
@@ -25,7 +25,6 @@ class Master extends ClusterProcess {
         this._masterOpts = {};
 
         this.pools = new Map();
-        this.createPool(DEFAULT_POOL_KEY);
 
         this.id = 0;
         this.wid = 0;
@@ -37,6 +36,10 @@ class Master extends ClusterProcess {
         process.on('SIGQUIT', this._onSignalQuit.bind(this));
     }
 
+    /**
+     * @param {*} key
+     * @returns {WorkerPool}
+     */
     createPool(key) {
         if (this.pools.has(key)) {
             throw LusterMasterError.createError(
@@ -53,8 +56,30 @@ class Master extends ClusterProcess {
         return pool;
     }
 
+    /**
+     * @param {*} key
+     * @returns {WorkerPool}
+     */
+    removePool(key) {
+        const pool = this.pools.get(key);
+        if (!pool) {
+            throw LusterMasterError.createError(
+                LusterMasterError.CODES.POOL_DOES_NOT_EXIST,
+                {key}
+            );
+        }
+
+        this.emit('remove pool', key);
+        this.pools.delete(key);
+        return pool;
+    }
+
     getPool(key) {
         return this.pools.get(key);
+    }
+
+    getDefaultPool() {
+        return this.getPool(DEFAULT_POOL_KEY);
     }
 
     /**
@@ -156,6 +181,20 @@ class Master extends ClusterProcess {
         this.emit('received worker ' + event, worker, ...args);
     }
 
+    configure(...args) {
+        this._setConfig(...args);
+
+        if (this.config) {
+            if (this.config.get('useDefaultPool', true)) {
+                this.createPool(DEFAULT_POOL_KEY).configure(this.config);
+            }
+
+            this.emit('configured');
+        }
+
+        return this;
+    }
+
     /**
      * Configure cluster
      * @override ClusterProcess
@@ -171,8 +210,6 @@ class Master extends ClusterProcess {
                 this.broadcastWorkerEvent.bind(this)
             );
         }
-
-        this.pools.get(DEFAULT_POOL_KEY).configure(this.config);
     }
 
     /**

--- a/lib/worker-pool.js
+++ b/lib/worker-pool.js
@@ -129,6 +129,22 @@ class WorkerPool extends EventEmitterEx {
     }
 
     /**
+     * Remove worker from the pool
+     * @param {WorkerWrapper} worker
+     * @returns {WorkerPool} self
+     * @public
+     */
+    remove(worker) {
+        // invalidate WorkerPool#getWorkersIds and WorkerPool#getWorkersArray cache
+        this._workersIdsCache = null;
+        this._workersArrayCache = null;
+
+        delete this.workers[worker.wid];
+
+        return this;
+    }
+
+    /**
      * Iterate over workers in the pool.
      * @param {Function} fn
      * @public


### PR DESCRIPTION
- Optional default pool creation.
- Added `Master#getDefaultPool()`.
- Added `Master#removePool(key)`.
- Added `WorkerPool#remove(worker)`.

Also this branch contains 53eb2c596e5a62f27bb36d8a587783be29b6fbbf from master.