### PR TITLE
fix: resolve symlink to bin script

### DIFF
--- a/bin/luster.js
+++ b/bin/luster.js
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 const /** @type {ClusterProcess} */
     luster = require('../lib/luster'),
+    fs = require('fs'),
     path = require('path');
 
 // config path is right after this script in process.argv
-const scriptArgvIndex = process.argv.findIndex(arg => arg === __filename || path.resolve(arg) === __filename);
+// path in the argument may be relative or symlink
+const scriptArgvIndex = process.argv.findIndex(arg => arg === __filename || fs.realpathSync(path.resolve(arg)) === __filename);
 const configFilePath = path.resolve(process.cwd(), process.argv[scriptArgvIndex + 1] || 'luster.conf');
 
 luster.configure(require(configFilePath), true, path.dirname(configFilePath)).run();


### PR DESCRIPTION
now the bin script fails to detect an itself position in args in the case it was passed via a symlink such as `node_modules/.bin/luster`