### PR TITLE
Add consistent debugger port for each worker with inspectPort option

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -30,13 +30,6 @@ class Master extends ClusterProcess {
          */
         this._restartQueue = new RestartQueue();
 
-        /**
-         * Configuration object to pass to cluster.setupMaster()
-         * @type {Object}
-         * @private
-         */
-        this._masterOpts = {};
-
         this.id = 0;
         this.wid = 0;
         this.pid = process.pid;
@@ -52,13 +45,12 @@ class Master extends ClusterProcess {
     /**
      * Allows same object structure as cluster.setupMaster().
      * This function must be used instead of cluster.setupMaster(),
-     * because all calls of cluster.setupMaster() ignored, except first one.
      * An instance of Master will call it, when running.
      * @param {Object} opts
-     * @see {@link http://nodejs.org/api/cluster.html#cluster_cluster_setupmaster_settings}
+     * @see {@link https://nodejs.org/api/cluster.html#clustersetupmastersettings}
      */
     setup(opts) {
-        Object.assign(this._masterOpts, opts);
+        cluster.setupMaster({...cluster.settings, ...opts});
     }
 
     /**
@@ -222,6 +214,7 @@ class Master extends ClusterProcess {
             isServerPortSet = this.config.has('server.port'),
             groups = this.config.get('server.groups', 1),
             portsPerGroup = this.config.get('server.portsPerGroup', 1),
+            masterInspectPort = this.config.get('properties.masterInspectPort'),
             workersPerGroup = Math.floor(count / groups);
 
         let port,
@@ -242,6 +235,7 @@ class Master extends ClusterProcess {
                 exitThreshold,
                 allowedSequentialDeaths,
                 port: isServerPortSet ? port.next(group * portsPerGroup) : 0,
+                masterInspectPort,
                 maxListeners: this.getMaxListeners(),
             }));
 
@@ -456,8 +450,6 @@ class Master extends ClusterProcess {
 
     async _run() {
         await this.whenInitialized();
-
-        cluster.setupMaster(this._masterOpts);
 
         // TODO maybe run this after starting waitForAllWorkers
         this.forEach(worker => worker.run());

--- a/lib/worker_wrapper.js
+++ b/lib/worker_wrapper.js
@@ -35,6 +35,7 @@ class WorkerWrapperOptions {
         this.exitThreshold = options.exitThreshold;
         this.allowedSequentialDeaths = options.allowedSequentialDeaths || 0;
         this.port = options.port;
+        this.masterInspectPort = options.masterInspectPort;
     }
 
     get port() {
@@ -129,6 +130,13 @@ class WorkerWrapper extends EventEmitterEx {
          * @type {Boolean}
          */
         this.dead = false;
+
+        /**
+         * Port for node v8 debugger on this worker.
+         * @type {Number}
+         * @public
+         */
+        this.inspectPort = this.options.masterInspectPort + this.wid;
 
         /**
          * Number of sequential deaths when worker life time was less than `exitThreshold` option value.
@@ -381,6 +389,10 @@ class WorkerWrapper extends EventEmitterEx {
         }
 
         setImmediate(() => {
+            // this call of setup sets inspectPort for node js debugger
+            // it should be here so that every worker can receive the same debugger port after restarting
+            this._master.setup({inspectPort: this.inspectPort})
+
             /** @private */
             this._worker = cluster.fork({
                 port: this.options.port,


### PR DESCRIPTION
Set consistent debugger port for each worker with inspectPort option for after soft-restart each worker has the same port.