### PR TITLE
Prevent kill of the restarted worker when "exit" event is triggered before "disconnect"

### DIFF
--- a/lib/worker_wrapper.js
+++ b/lib/worker_wrapper.js
@@ -250,8 +250,13 @@ class WorkerWrapper extends EventEmitterEx {
      * @private
      */
     _onDisconnect() {
-        this.ready = false;
-        this._setState(WorkerWrapper.STATES.STOPPING);
+        // "disconnect" and "exit" may be triggered in any order:
+        //  https://nodejs.org/docs/latest-v22.x/api/cluster.html#clusterworkers
+        // Check state is stoppable for coordination.
+        if (this.isRunning()) {
+            this.ready = false;
+            this._setState(WorkerWrapper.STATES.STOPPING);
+        }
     }
 
     /**


### PR DESCRIPTION
Doc explicitly says there is no guarantee on the events order - https://nodejs.org/docs/latest-v22.x/api/cluster.html#clusterworkers. And this happens in practice.